### PR TITLE
Update fixed order cost

### DIFF
--- a/controllers/models/Products.js
+++ b/controllers/models/Products.js
@@ -146,7 +146,7 @@ var Products = {
         this.products = products;
     },
 
-    SetProduct : function(uid, newProduct) {
+    setProduct(uid, newProduct) {
         for (var i = 0; i < this.products.length; i++) {
             if (this.products[i].uid == uid) {
                 var product = createValidProduct(newProduct);
@@ -222,14 +222,15 @@ function filterForExistingProducts(products) {
 }
 
 function createValidProduct(np) {
-    var product = {
+    let product = {
         "product_id": np.product_id ? np.product_id : "100",
         "name": np.name ? np.name : "Unnamed product",
         "quality": np.quality ? np.quality : 4,
         "price": np.price ? np.price : 15,
         "stock": np.stock ? np.stock : -1,
         "time_to_live": np.time_to_live ? np.time_to_live : -1,
-        "start_of_lifetime": np.start_of_lifetime ? np.start_of_lifetime : -1
+        "start_of_lifetime": np.start_of_lifetime ? np.start_of_lifetime : -1,
+        "fixed_order_cost": np.fixed_order_cost ? np.fixed_order_cost : 0,
     };
     product.uid = parseInt("" + product.product_id + product.quality);
     return product;

--- a/controllers/routes/routes.js
+++ b/controllers/routes/routes.js
@@ -66,19 +66,12 @@ var appRouter = function(app) {
                     "message": "a product with this uid does not exist"
                 });
             }
-            if (Object.prototype.toString.call( req.body ) === '[object Array]' ) {
-                if (Products.SetProduct(parseInt(req.params.uid), req.body[0])) {
-                    return res.status(200).send();
-                } else {
-                    return res.status(404).send({
-                        "code": 404,
-                        "message": "other products than the one with the specified UID would be overwritten",
-                    });
-                }
+            if (Products.setProduct(parseInt(req.params.uid), req.body)) {
+                return res.status(200).send();
             } else {
-                return res.status(406).send({
-                    "code": 406,
-                    "message": "product has to be in the form of an array"
+                return res.status(404).send({
+                    "code": 404,
+                    "message": "other products than the one with the specified UID would be overwritten"
                 });
             }
         })


### PR DESCRIPTION
With this PR it is possible to update a product's holding cost. E.g. if it is changed in the management UI

Small API change: the PUT /products/<uid> route does not require an array of a single product anymore. Instead, the request should directly contain the product.